### PR TITLE
Deep-link directly to Slack channels

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
     <p>Our community currently lives on the
     <a href="http://chicagotechslack.com">Chicago Tech Slack</a> in the
-    #nodejs and #javascript channels.</p>
+    <a href="slack://channel?team=T08UCAYN6&id=C0CJC2HPA">#nodejs</a> and <a href="slack://channel?team=T08UCAYN6&id=C08UN3E3W">#javascript</a> channels.</p>
 
     <p>Source for this page is available in our
     <a href="https://github.com/ChicagoJS">GitHub Organization</a>.


### PR DESCRIPTION
Add link to "#nodejs" and "#javascript" to open Slack client directly into the specific channels.

**Link Format:** `slack://channel?team={TEAM_ID}&id={CHANNEL_ID}`